### PR TITLE
Update bertin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/davidbrochart/ipybertin/branch/master/graph/badge.svg)](https://codecov.io/gh/davidbrochart/ipybertin)
 
 
-A Jupyter - Bertin.js bridge
+A Jupyter - [Bertin](https://github.com/neocarto/bertin) bridge
 
 ## Installation
 

--- a/ipybertin/_version.py
+++ b/ipybertin/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) David Brochart.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 1, 0)
+version_info = (0, 2, 0)
 __version__ = ".".join(map(str, version_info))

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2.0.0 || ^3.0.0 || ^4.0.0",
-    "bertin": "^0.12.0",
+    "bertin": "^1.5.9",
     "d3": "^7.4.4",
     "d3-geo": "^3.0.1",
     "d3-geo-projection": "^4.0.0"


### PR DESCRIPTION
Thanks for making this jupyter extension !

In this PR I propose to update bertin dependency in order to use the latest version available on NPM (1.5.9).
I also changed the name of bertin library in the README (from "bertin.js" to "bertin" because it seems, after discussing with @neocarto, that it's the correct way to name it ).

As it could be beneficial to release a new version (linked to the latest bertin library) I took the liberty to bump ipybertin version number to 0.1.0 to 0.2.0 but don't hesitate to tell me if other changes are needed before releasing a new version !